### PR TITLE
Add platform SN3750SX

### DIFF
--- a/packages/base/all/vendor-config-onl/src/python/onl/platform/base.py
+++ b/packages/base/all/vendor-config-onl/src/python/onl/platform/base.py
@@ -533,6 +533,10 @@ class OnlPlatformPortConfig_60x100(object):
     PORT_COUNT=60
     PORT_CONFIG="60x100"
 
+class OnlPlatformPortConfig_32x200(object):
+    PORT_COUNT=32
+    PORT_CONFIG="32x200"
+
 class OnlPlatformPortConfig_64x100(object):
     PORT_COUNT=64
     PORT_CONFIG="64x100"

--- a/packages/platforms/mellanox/x86-64/msn3700/onlp/builds/x86_64_mlnx_msn3700/module/src/sysi.c
+++ b/packages/platforms/mellanox/x86-64/msn3700/onlp/builds/x86_64_mlnx_msn3700/module/src/sysi.c
@@ -89,7 +89,12 @@ onlp_sysi_platform_set(const char* platform)
         mlnx_platform = get_platform_info();
         mc_get_platform_info(mlnx_platform);
         return ONLP_STATUS_OK;
-    } else if(!strcmp(platform, "x86-64-mlnx-msn3700-all")) {
+    } else if(!strcmp(platform, "x86-64-nvidia-sn3750sx-r0")) {
+        __ONL_PLATFORM_NAME = "x86-64-nvidia_sn3750sx-r0";
+        mlnx_platform = get_platform_info();
+        mc_get_platform_info(mlnx_platform);
+        return ONLP_STATUS_OK;
+	} else if(!strcmp(platform, "x86-64-mlnx-msn3700-all")) {
         __ONL_PLATFORM_NAME = "x86-64-mlnx-msn3700-all";
         return ONLP_STATUS_OK;
     }

--- a/packages/platforms/mellanox/x86-64/sn3750sx/Makefile
+++ b/packages/platforms/mellanox/x86-64/sn3750sx/Makefile
@@ -1,0 +1,1 @@
+include $(ONL)/make/pkg.mk

--- a/packages/platforms/mellanox/x86-64/sn3750sx/modules/Makefile
+++ b/packages/platforms/mellanox/x86-64/sn3750sx/modules/Makefile
@@ -1,0 +1,1 @@
+include $(ONL)/make/pkg.mk

--- a/packages/platforms/mellanox/x86-64/sn3750sx/modules/PKG.yml
+++ b/packages/platforms/mellanox/x86-64/sn3750sx/modules/PKG.yml
@@ -1,0 +1,1 @@
+!include $ONL_TEMPLATES/no-platform-modules.yml ARCH=amd64 VENDOR=mellanox BASENAME=x86-64-nvidia-sn3750sx

--- a/packages/platforms/mellanox/x86-64/sn3750sx/onlp/Makefile
+++ b/packages/platforms/mellanox/x86-64/sn3750sx/onlp/Makefile
@@ -1,0 +1,1 @@
+include $(ONL)/make/pkg.mk

--- a/packages/platforms/mellanox/x86-64/sn3750sx/onlp/PKG.yml
+++ b/packages/platforms/mellanox/x86-64/sn3750sx/onlp/PKG.yml
@@ -1,0 +1,1 @@
+!include $ONL_TEMPLATES/onlp-platform-any.yml PLATFORM=x86-64-nvidia-sn3750sx ARCH=amd64 TOOLCHAIN=x86_64-linux-gnu

--- a/packages/platforms/mellanox/x86-64/sn3750sx/onlp/builds/.gitignore
+++ b/packages/platforms/mellanox/x86-64/sn3750sx/onlp/builds/.gitignore
@@ -1,0 +1,1 @@
+x86_64_nvidia_sn3750sx.mk

--- a/packages/platforms/mellanox/x86-64/sn3750sx/onlp/builds/Makefile
+++ b/packages/platforms/mellanox/x86-64/sn3750sx/onlp/builds/Makefile
@@ -1,0 +1,2 @@
+FILTER=src
+include $(ONL)/make/subdirs.mk

--- a/packages/platforms/mellanox/x86-64/sn3750sx/onlp/builds/lib/Makefile
+++ b/packages/platforms/mellanox/x86-64/sn3750sx/onlp/builds/lib/Makefile
@@ -1,0 +1,4 @@
+PLATFORM := x86-64-nvidia-sn3750sx
+PLATFORM_MODULE := x86_64_mlnx_msn3700
+EXTRA_MODULES := mlnx_common
+include $(ONL)/packages/base/any/onlp/builds/platform/libonlp-platform.mk

--- a/packages/platforms/mellanox/x86-64/sn3750sx/onlp/builds/onlpdump/Makefile
+++ b/packages/platforms/mellanox/x86-64/sn3750sx/onlp/builds/onlpdump/Makefile
@@ -1,0 +1,4 @@
+PLATFORM := x86-64-nvidia-sn3750sx
+PLATFORM_MODULE := x86_64_mlnx_msn3700
+EXTRA_MODULES := mlnx_common
+include $(ONL)/packages/base/any/onlp/builds/platform/onlps.mk

--- a/packages/platforms/mellanox/x86-64/sn3750sx/platform-config/Makefile
+++ b/packages/platforms/mellanox/x86-64/sn3750sx/platform-config/Makefile
@@ -1,0 +1,1 @@
+include $(ONL)/make/pkg.mk

--- a/packages/platforms/mellanox/x86-64/sn3750sx/platform-config/r0/Makefile
+++ b/packages/platforms/mellanox/x86-64/sn3750sx/platform-config/r0/Makefile
@@ -1,0 +1,1 @@
+include $(ONL)/make/pkg.mk

--- a/packages/platforms/mellanox/x86-64/sn3750sx/platform-config/r0/PKG.yml
+++ b/packages/platforms/mellanox/x86-64/sn3750sx/platform-config/r0/PKG.yml
@@ -1,0 +1,1 @@
+!include $ONL_TEMPLATES/platform-config-platform.yml ARCH=amd64 VENDOR=mellanox BASENAME=x86-64-nvidia-sn3750sx REVISION=r0

--- a/packages/platforms/mellanox/x86-64/sn3750sx/platform-config/r0/src/lib/x86-64-nvidia-sn3750sx-r0.yml
+++ b/packages/platforms/mellanox/x86-64/sn3750sx/platform-config/r0/src/lib/x86-64-nvidia-sn3750sx-r0.yml
@@ -1,0 +1,35 @@
+---
+
+######################################################################
+#
+# platform-config for Nvidia sn3750sx
+#
+######################################################################
+
+x86-64-nvidia-sn3750sx-r0:
+
+  grub:
+
+    serial: >-
+      --unit=0
+      --speed=115200
+      --word=8
+      --parity=0
+      --stop=1
+
+    kernel:
+      <<: *kernel-5-10
+
+    args: >-
+      nopat
+      console=ttyS0,115200n8
+      rd_NO_MD
+      rd_NO_LUKS
+      i2c-ismt.enable=0
+      i2c_i801.disable_features=0x10  
+
+  ##network
+  ##  interfaces:
+  ##    ma1:
+  ##      name: ~
+  ##      syspath: pci0000:00/0000:00:14.0

--- a/packages/platforms/mellanox/x86-64/sn3750sx/platform-config/r0/src/python/x86_64_nvidia_sn3750sx_r0/__init__.py
+++ b/packages/platforms/mellanox/x86-64/sn3750sx/platform-config/r0/src/python/x86_64_nvidia_sn3750sx_r0/__init__.py
@@ -1,0 +1,16 @@
+from onl.platform.base import *
+from onl.platform.nvidia import *
+
+class OnlPlatform_x86_64_nvidia_sn3750sx_r0(OnlPlatformNvidia,
+                                               OnlPlatformPortConfig_32x200):
+    PLATFORM='x86-64-nvidia-sn3750sx-r0'
+    MODEL="SN3750SX"
+    SYS_OBJECT_ID=".sn3750sx.1"
+
+    def baseconfig(self):
+        # load modules
+        import os
+        # necessary if there are issues with the install
+        # os.system("/usr/bin/apt-get install")
+        self.syseeprom_export();
+        return True


### PR DESCRIPTION
This platform is a re-spin of msn3700 (Anaconda) platform with
secure boot enabled and having support for PTP, SyncE, PPS.

Platform has:
 - 32x200G Spectrum-2 ASIC
 - Secure BIOS / CPLD
 - 6 Fans
 - 2 PSUs
 - Intel Coffee Lake CPU

Signed-off-by: Ciju Rajan K <crajank@nvidia.com>